### PR TITLE
Change few settings on per world basis and add custom despawn times

### DIFF
--- a/paper-world-defaults.yml
+++ b/paper-world-defaults.yml
@@ -5,26 +5,6 @@ anticheat:
     engine-mode: 1
     hidden-blocks:
     - copper_ore
-    - deepslate_copper_ore
-    - gold_ore
-    - deepslate_gold_ore
-    - iron_ore
-    - deepslate_iron_ore
-    - coal_ore
-    - deepslate_coal_ore
-    - lapis_ore
-    - deepslate_lapis_ore
-    - mossy_cobblestone
-    - obsidian
-    - chest
-    - diamond_ore
-    - deepslate_diamond_ore
-    - redstone_ore
-    - deepslate_redstone_ore
-    - clay
-    - emerald_ore
-    - deepslate_emerald_ore
-    - ender_chest
     lava-obscures: false
     max-block-height: 64
     replacement-blocks:
@@ -132,13 +112,37 @@ entities:
   spawning:
     all-chunks-are-slime-chunks: false
     alt-item-despawn-rate:
-    #FUTURE Update with timings per item type, potential to customise per world depending on drops
-    ##FUTURE Kaya - Removed SPOT items, excited to see your PR.
+    #FUTURE Go thorugh all items - currenlty low hanging fruit
       enabled: true
       items:
         netherrack: 1200
+        rail: 600
+        powered_rail: 600
+        detector_rail: 600
+        activator_rail: 600
+        white_carpet: 1200
+        orange_carpet: 1200
+        magenta_carpet: 1200
+        light_blue_carpet: 1200
+        yellow_carpet: 1200
+        lime_carpet: 1200
+        pink_carpet: 1200
+        gray_carpet: 1200
+        light_gray_carpet: 1200
+        cyan_carpet: 1200
+        purple_carpet: 1200
+        blue_carpet: 1200
+        brown_carpet: 1200
+        green_carpet: 1200
+        red_carpet: 1200
+        black_carpet: 1200
+        dirt: 2400
+        stone: 2400
+        cobblestone: 2400
+        rotten_flesh: 1200
+
     count-all-mobs-for-spawning: false
-    creative-arrow-despawn-rate: default
+    creative-arrow-despawn-rate: 20
     despawn-ranges:
       ambient:
         hard: 64

--- a/per-world-settings/paper-world-events.yml
+++ b/per-world-settings/paper-world-events.yml
@@ -10,7 +10,6 @@ entities:
       disable: false
   spawning:
     alt-item-despawn-rate:
-    #FUTURE Update with timings per item type, potential to customise per world depending on drops
       enabled: true
       items:
         netherrack: 1200

--- a/per-world-settings/paper-world-nest.yml
+++ b/per-world-settings/paper-world-nest.yml
@@ -5,4 +5,10 @@
 
 _version: 30
 
-# Nothing to change, this will be the same as defaults if left blank.
+spawn:
+  # here as a discussion point but given that the mall sits at the center of the map is it
+  # worth keeping at least some of spawn loaded at all time to cover /mall warp to prevent loading/unloaded.
+  # Mall itself is off center so to prevent auto farms we would need to claim area to the south to cover more of
+  # the mall itself
+  keep-spawn-loaded: false
+  keep-spawn-loaded-range: 10

--- a/per-world-settings/paper-world-resourcenest.yml
+++ b/per-world-settings/paper-world-resourcenest.yml
@@ -4,6 +4,8 @@
 # World: ResourceNest (minecraft:resourcenest)
 
 _version: 30
+chunks:
+  auto-save-interval: 12000
 entities:
   behavior:
     nerf-pigmen-from-nether-portals: false

--- a/per-world-settings/paper-world-resourcenest_nether.yml
+++ b/per-world-settings/paper-world-resourcenest_nether.yml
@@ -4,6 +4,8 @@
 # World: ResourceNest_nether (minecraft:resourcenest_nether)
 
 _version: 30
+chunks:
+  auto-save-interval: 12000
 entities:
   behavior:
     nerf-pigmen-from-nether-portals: false


### PR DESCRIPTION
Currenlty only low hanging fruit for despawn times on items, ones that are most common and likely to cause issues on server. Rest can be a followup but may be better after the anti-lag plugin