### PR TITLE
RUNTIME FIXES - spigot.yml

### DIFF
--- a/spigot.yml
+++ b/spigot.yml
@@ -209,7 +209,7 @@ world-settings:
       villagers-active-for-panic: false
       tick-inactive-villagers: false
       ignore-spectators: false
-   ResourceNest_Nether:
+  ResourceNest_Nether:
     view-distance: 6
     simulation-distance: 2
     item-despawn-rate: 3000


### PR DESCRIPTION
Fails at runtime with:

administrator@minecraft001:~$ ./start.sh
Starting org.bukkit.craftbukkit.Main
System Info: Java 17 (OpenJDK 64-Bit Server VM 17.0.6+10-Ubuntu-0ubuntu122.04) Host: Linux 5.15.0-60-generic (amd64) Loading libraries, please wait...
[17:33:16 ERROR]: Failed to start the minecraft server java.lang.Exception: Failed to load configuration file: spigot.yml
	at io.papermc.paper.configuration.PaperConfigurations.loadLegacyConfigFile(PaperConfigurations.java:419) ~[purpur-1.19.4.jar:git-Purpur-1966]
	at net.minecraft.server.Main.main(Main.java:138) ~[purpur-1.19.4.jar:git-Purpur-1966]
	at org.bukkit.craftbukkit.Main.main(Main.java:323) ~[purpur-1.19.4.jar:git-Purpur-1966]
	at io.papermc.paperclip.Paperclip.lambda$main$0(Paperclip.java:42) ~[app:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.bukkit.configuration.InvalidConfigurationException: while parsing a block mapping
 in 'reader', line 53, column 3:
      default:
      ^
expected <block end>, but found '<block mapping start>'
 in 'reader', line 212, column 4:
       ResourceNest_Nether:
       ^

	at org.bukkit.configuration.file.YamlConfiguration.loadFromString(YamlConfiguration.java:106) ~[purpur-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.configuration.file.FileConfiguration.load(FileConfiguration.java:160) ~[purpur-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.configuration.file.FileConfiguration.load(FileConfiguration.java:128) ~[purpur-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.configuration.PaperConfigurations.loadLegacyConfigFile(PaperConfigurations.java:417) ~[purpur-1.19.4.jar:git-Purpur-1966]
	... 4 more